### PR TITLE
Add a 'getOrElse()' function 

### DIFF
--- a/src/main/kotlin/nl/zienit/functional/Try.kt
+++ b/src/main/kotlin/nl/zienit/functional/Try.kt
@@ -9,6 +9,8 @@ sealed class Try<T> {
     abstract fun isFailure(): Boolean
     abstract fun get(): T
     abstract fun getException(): Throwable
+    fun getOrElse(other: T): T = if(this.isSuccess()) this.get() else other
+    fun getOrNull(): T? = if(this.isSuccess()) this.get() else null
     abstract fun <U> map(mapper: (T) -> U): Try<U>
     abstract fun <U> flatMap(mapper: (T) -> Try<out U>): Try<U>
     abstract fun filter(predicate: (T) -> Boolean): Try<T>

--- a/src/test/kotlin/nl/zienit/functional/TryTest.kt
+++ b/src/test/kotlin/nl/zienit/functional/TryTest.kt
@@ -153,4 +153,16 @@ class TryTest {
 
         assertThat(u.get().x, equalTo(3))
     }
+
+    @Test
+    fun testGetOrElse() {
+        val t: Try<B> = NullPointerException("foo").failure()
+        assertThat(t.getOrElse(B(12)).x, equalTo(12))
+    }
+
+    @Test
+    fun testGetOrNull() {
+        val t: Try<B> = NullPointerException("foo").failure()
+        assertThat(t.getOrNull(), equalTo<B?>(null))
+    }
 }


### PR DESCRIPTION
Add a `getOrElse()` and `getOrNull()` functions that respectively return an alternative result and `null` if the try is a failure.